### PR TITLE
Fix script injection and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/content/contentScript.js
+++ b/content/contentScript.js
@@ -41,5 +41,10 @@ function generateSelector(el) {
 chrome.runtime.onMessage.addListener((msg) => {
   if (msg.type === "start-inspect") {
     inspectMode();
+  } else if (msg.type === "inject-userscript" && msg.script) {
+    const s = document.createElement("script");
+    s.textContent = msg.script;
+    (document.head || document.documentElement).appendChild(s);
+    s.remove();
   }
 });

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,3 @@ MIT — free to adapt, build on, and share with attribution.
     LLogos — because sometimes all you need is the right word to reshape the web.
 
 
----
-
-Would you like me to add this as a file in your working project or format it for `index.md` if you’re planning to publish a GitHub Pages site?
-


### PR DESCRIPTION
## Summary
- wire up listener for `inject-userscript` message
- trim leftover sentence from `readme.md`
- add MIT license text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68436a9000d483219335eb3d4b5d255a