### PR TITLE
Enable ctrl+click multi-select

### DIFF
--- a/content/contentScript.js
+++ b/content/contentScript.js
@@ -1,48 +1,77 @@
 let selectedElements = [];
+let currentHover = null;
 
-function highlightElement(el) {
-  if (!el.classList.contains("llogos-highlight")) {
-    el.classList.add("llogos-highlight");
+function hoverElement(el) {
+  if (currentHover && currentHover !== el) {
+    currentHover.classList.remove('llogos-hover');
+  }
+  currentHover = el;
+  if (!el.classList.contains('llogos-hover') && !el.classList.contains('llogos-selected')) {
+    el.classList.add('llogos-hover');
+  }
+}
+
+function selectElement(el) {
+  if (!selectedElements.includes(el)) {
+    el.classList.remove('llogos-hover');
+    el.classList.add('llogos-selected');
     selectedElements.push(el);
   }
+}
+
+function clearHighlights() {
+  selectedElements.forEach(el => el.classList.remove('llogos-selected'));
+  if (currentHover) currentHover.classList.remove('llogos-hover');
+  selectedElements = [];
+  currentHover = null;
 }
 
 function inspectMode() {
   const hoverHandler = (e) => {
     e.stopPropagation();
-    highlightElement(e.target);
+    hoverElement(e.target);
   };
 
-  document.body.addEventListener("mouseover", hoverHandler, true);
-
-  document.body.addEventListener("click", (e) => {
+  const clickHandler = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    document.body.removeEventListener("mouseover", hoverHandler);
+    if (e.ctrlKey) {
+      selectElement(e.target);
+      return;
+    }
 
-    const elementsData = selectedElements.map((el) => ({
+    document.body.removeEventListener('mouseover', hoverHandler, true);
+    document.body.removeEventListener('click', clickHandler, true);
+
+    if (!selectedElements.includes(e.target)) {
+      selectedElements.push(e.target);
+    }
+
+    const elementsData = selectedElements.map(el => ({
       html: el.outerHTML,
       selector: generateSelector(el)
     }));
 
-    chrome.runtime.sendMessage({ type: "elements-selected", elements: elementsData });
+    chrome.runtime.sendMessage({ type: 'elements-selected', elements: elementsData });
 
-    selectedElements.forEach(el => el.classList.remove("llogos-highlight"));
-    selectedElements = [];
-  }, { once: true });
+    clearHighlights();
+  };
+
+  document.body.addEventListener('mouseover', hoverHandler, true);
+  document.body.addEventListener('click', clickHandler, true);
 }
 
 function generateSelector(el) {
   const tag = el.tagName.toLowerCase();
-  const classString = el.className ? "." + el.className.trim().replace(/\s+/g, ".") : "";
+  const classString = el.className ? '.' + el.className.trim().replace(/\s+/g, '.') : '';
   return `${tag}${classString}`;
 }
 
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.type === "start-inspect") {
+  if (msg.type === 'start-inspect') {
     inspectMode();
-  } else if (msg.type === "inject-userscript" && msg.script) {
-    const s = document.createElement("script");
+  } else if (msg.type === 'inject-userscript' && msg.script) {
+    const s = document.createElement('script');
     s.textContent = msg.script;
     (document.head || document.documentElement).appendChild(s);
     s.remove();

--- a/content/highlighter.css
+++ b/content/highlighter.css
@@ -1,4 +1,9 @@
-.llogos-highlight {
+.llogos-hover {
   outline: 2px solid #00f !important;
   background-color: rgba(0, 0, 255, 0.1) !important;
+}
+
+.llogos-selected {
+  outline: 2px solid yellow !important;
+  background-color: rgba(255, 255, 0, 0.3) !important;
 }

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,10 @@ LLogos is a Firefox browser extension that empowers users to describe visual cha
 - `Settings` button opens a separate options page to manage your LLM API key.
 
 ### 🔎 Inspect Mode
-- Hover over any number of elements on a page.
-- Click one final time to confirm selection.
-- Highlighted elements are gathered for LLM prompt preparation.
+- Hover highlights the element under your cursor.
+- Ctrl+click to add elements to the selection.
+- A regular click finalizes the current selection.
+- Selected elements are gathered for LLM prompt preparation.
 
 ### 💡 DOM Snapshot & Selector Collection
 - For each selected element:


### PR DESCRIPTION
## Summary
- highlight element on hover only
- ctrl+click to select multiple elements
- click to finalize selection
- style selected nodes in yellow
- document new inspect mode behavior

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68436fc988a48321a286e1d138ace9a6