### PR TITLE
Add extension parity to docs playground

### DIFF
--- a/docs/playground.html
+++ b/docs/playground.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1>LLogos Dev Playground</h1>
-  <p>Tap elements to highlight them. Then click "Simulate LLM Action" to see what would happen.</p>
+  <p>Select elements using <em>Start Inspect Mode</em>. Ctrl+click to select multiple items then click again to finish.</p>
 
   <div class="playground-container">
     <div class="card">Card A</div>
@@ -17,8 +17,9 @@
   </div>
 
   <div class="actions">
-    <button onclick="simulateLLMAction()">Simulate LLM Action</button>
-    <button onclick="clearSelection()">Clear</button>
+    <button id="inspectBtn">Start Inspect Mode</button>
+    <button id="openChatBtn">Open Chat</button>
+    <button id="clearBtn">Clear</button>
   </div>
 
   <script src="playground.js"></script>

--- a/docs/playground.js
+++ b/docs/playground.js
@@ -1,25 +1,163 @@
-const selected = [];
+// Single-page version of the extension logic
+let selectedElements = [];
+let currentHover = null;
 
-function highlight(el) {
-  if (!selected.includes(el)) {
-    el.classList.add('highlight');
-    selected.push(el);
+function hoverElement(el) {
+  if (currentHover && currentHover !== el) {
+    currentHover.classList.remove('llogos-hover');
+  }
+  currentHover = el;
+  if (!el.classList.contains('llogos-hover') && !el.classList.contains('llogos-selected')) {
+    el.classList.add('llogos-hover');
   }
 }
 
-function clearSelection() {
-  selected.forEach(el => el.classList.remove('highlight'));
-  selected.length = 0;
+function selectElement(el) {
+  if (!selectedElements.includes(el)) {
+    el.classList.remove('llogos-hover');
+    el.classList.add('llogos-selected');
+    selectedElements.push(el);
+  }
 }
 
-function simulateLLMAction() {
-  selected.forEach(el => {
-    el.style.textAlign = 'left';
-    el.style.backgroundColor = '#d6f5d6';
-    el.textContent += ' (Left aligned)';
+function clearHighlights() {
+  selectedElements.forEach(el => el.classList.remove('llogos-selected'));
+  if (currentHover) currentHover.classList.remove('llogos-hover');
+  selectedElements = [];
+  currentHover = null;
+}
+
+function generateSelector(el) {
+  const tag = el.tagName.toLowerCase();
+  const classString = el.className ? '.' + el.className.trim().replace(/\s+/g, '.') : '';
+  return `${tag}${classString}`;
+}
+
+function generateUserScript(selectors) {
+  return `// ==UserScript==\n// @name Hide Elements\n// @match *://*/*\n// ==/UserScript==\n\n(function() {\n  document.querySelectorAll('${selectors}').forEach(el => el.style.display = 'none');\n})();`;
+}
+
+function injectUserScript(script) {
+  const s = document.createElement('script');
+  s.textContent = script;
+  (document.head || document.documentElement).appendChild(s);
+  s.remove();
+}
+
+function showLLMResponse(scriptText) {
+  const box = document.createElement('div');
+  box.className = 'llogos-response';
+  const close = document.createElement('button');
+  close.textContent = 'Close';
+  close.addEventListener('click', () => box.remove());
+  const pre = document.createElement('pre');
+  pre.textContent = scriptText;
+  box.appendChild(close);
+  box.appendChild(pre);
+  document.body.appendChild(box);
+}
+
+function inspectMode() {
+  clearHighlights();
+  const hoverHandler = e => {
+    e.stopPropagation();
+    hoverElement(e.target);
+  };
+  const clickHandler = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.ctrlKey) {
+      selectElement(e.target);
+      return;
+    }
+    document.body.removeEventListener('mouseover', hoverHandler, true);
+    document.body.removeEventListener('click', clickHandler, true);
+    if (!selectedElements.includes(e.target)) {
+      selectedElements.push(e.target);
+    }
+    const selectors = selectedElements.map(el => generateSelector(el)).join(', ');
+    const script = generateUserScript(selectors);
+    injectUserScript(script);
+    showLLMResponse(script);
+    clearHighlights();
+  };
+  document.body.addEventListener('mouseover', hoverHandler, true);
+  document.body.addEventListener('click', clickHandler, true);
+}
+
+function addMessageToContainer(sender, text, isError) {
+  const container = document.getElementById('llogos-chat-messages');
+  if (!container) return;
+  const msgDiv = document.createElement('div');
+  msgDiv.style.marginBottom = '8px';
+  const senderSpan = document.createElement('span');
+  senderSpan.style.fontWeight = 'bold';
+  senderSpan.textContent = sender + ': ';
+  const contentSpan = document.createElement('span');
+  if (isError) contentSpan.style.color = 'red';
+  contentSpan.textContent = text;
+  msgDiv.appendChild(senderSpan);
+  msgDiv.appendChild(contentSpan);
+  container.appendChild(msgDiv);
+  container.scrollTop = container.scrollHeight;
+}
+
+function openChatSidebar() {
+  if (document.getElementById('llogos-chat-sidebar')) return;
+  const sidebar = document.createElement('div');
+  sidebar.id = 'llogos-chat-sidebar';
+  document.body.appendChild(sidebar);
+
+  const header = document.createElement('div');
+  header.id = 'llogos-chat-header';
+  const title = document.createElement('div');
+  title.textContent = 'Chat';
+  title.style.fontWeight = 'bold';
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '✖';
+  closeBtn.addEventListener('click', () => sidebar.remove());
+  header.appendChild(title);
+  header.appendChild(closeBtn);
+  sidebar.appendChild(header);
+
+  const messagesContainer = document.createElement('div');
+  messagesContainer.id = 'llogos-chat-messages';
+  const initialMsg = document.createElement('div');
+  initialMsg.style.marginBottom = '8px';
+  initialMsg.style.color = '#ccc';
+  initialMsg.style.fontStyle = 'italic';
+  initialMsg.textContent = "Describe the update you'd like to make to this site";
+  messagesContainer.appendChild(initialMsg);
+  sidebar.appendChild(messagesContainer);
+
+  const inputContainer = document.createElement('div');
+  inputContainer.id = 'llogos-chat-input-container';
+  const input = document.createElement('textarea');
+  input.id = 'llogos-chat-input';
+  input.rows = 2;
+  input.placeholder = 'Ask about modifications...';
+  const sendBtn = document.createElement('button');
+  sendBtn.id = 'llogos-chat-send';
+  sendBtn.textContent = 'Send';
+  sendBtn.addEventListener('click', () => {
+    const text = input.value.trim();
+    if (!text) return;
+    addMessageToContainer('You', text);
+    input.value = '';
+    // In this standalone page we simply echo the prompt as the AI response
+    setTimeout(() => addMessageToContainer('AI', `You said: ${text}`), 300);
   });
+  input.addEventListener('keypress', e => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendBtn.click();
+    }
+  });
+  inputContainer.appendChild(input);
+  inputContainer.appendChild(sendBtn);
+  sidebar.appendChild(inputContainer);
 }
 
-document.querySelectorAll('.card').forEach(card => {
-  card.addEventListener('click', () => highlight(card));
-});
+document.getElementById('inspectBtn').addEventListener('click', inspectMode);
+document.getElementById('openChatBtn').addEventListener('click', openChatSidebar);
+document.getElementById('clearBtn').addEventListener('click', clearHighlights);

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,6 +5,20 @@ body {
   margin: auto;
 }
 
+button {
+  margin-top: 0.5rem;
+  background-color: #333;
+  color: #eee;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #444;
+}
+
 .playground-container {
   display: flex;
   gap: 1rem;
@@ -20,13 +34,98 @@ body {
   text-align: center;
 }
 
-.card.highlight {
-  outline: 3px solid #00f;
-  background-color: #e0f0ff;
+
+.llogos-hover {
+  outline: 2px solid #00f !important;
+  background-color: rgba(0, 0, 255, 0.1) !important;
 }
+
+.llogos-selected {
+  outline: 2px solid yellow !important;
+  background-color: rgba(255, 255, 0, 0.3) !important;
+}
+
+.llogos-response {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 2147483647;
+  background: #2e2e2e;
+  border: 1px solid #444;
+  color: #eee;
+  padding: 8px;
+  font-family: monospace;
+  max-width: 300px;
+  max-height: 200px;
+  overflow: auto;
+}
+
 
 .actions {
   margin-top: 1rem;
   display: flex;
   justify-content: space-between;
+}
+
+/* Chat sidebar styles */
+#llogos-chat-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 350px;
+  background-color: #1e1e1e;
+  border-left: 1px solid #444;
+  z-index: 2147483647;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.8);
+}
+
+#llogos-chat-header {
+  flex: 0 0 auto;
+  padding: 8px;
+  background: #333;
+  border-bottom: 1px solid #444;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#llogos-chat-messages {
+  flex: 1 1 auto;
+  padding: 8px;
+  overflow-y: auto;
+  color: #eee;
+}
+
+#llogos-chat-input-container {
+  flex: 0 0 auto;
+  padding: 8px;
+  border-top: 1px solid #444;
+  display: flex;
+}
+
+#llogos-chat-input {
+  flex: 1;
+  resize: none;
+  background-color: #2e2e2e;
+  border: 1px solid #444;
+  color: #eee;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+#llogos-chat-send {
+  margin-left: 4px;
+  background-color: #333;
+  border: none;
+  color: #eee;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#llogos-chat-send:hover {
+  background-color: #444;
 }


### PR DESCRIPTION
## Summary
- improve the standalone playground to mirror extension features
- update HTML layout with inspect, chat and clear buttons
- style playground buttons, highlights, overlay and chat sidebar
- implement inspect mode, chat sidebar and userscript injection in `playground.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844320fe9ec8321a195a04c6093e593